### PR TITLE
Fixed cleanup of multi handles

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -31,6 +31,7 @@ typedef struct BufInfo {
 void * getCurlPointerForData(SEXP el, CURLoption option, Rboolean isProtected, CURL *handle);
 SEXP makeCURLcodeRObject(CURLcode val);
 CURL *getCURLPointerRObject(SEXP obj);
+CURLM *getCURLMPointerRObject(SEXP obj);
 SEXP makeCURLPointerRObject(CURL *obj, int addFinalizer);
 char *getCurlError(CURL *h, int throw, CURLcode status);
 SEXP RCreateNamesVec(const char * const *vals,  int n);
@@ -1230,6 +1231,31 @@ getCURLPointerRObject(SEXP obj)
 	return(handle);
 }
 
+CURLM *
+getCURLMPointerRObject(SEXP obj)
+{
+	CURLM *handle;
+	SEXP ref;
+	if(TYPEOF(obj) != EXTPTRSXP)
+   	   ref = GET_SLOT(obj, Rf_install("ref"));
+	else
+    	   ref = obj;
+
+	handle = (CURLM *) R_ExternalPtrAddr(ref);
+	if(!handle) {
+		PROBLEM "Stale CURLM handle being passed to libcurl"
+		ERROR;
+	}
+
+	if(R_ExternalPtrTag(ref) != Rf_install("MultiCURLHandle")) {
+		PROBLEM "External pointer with wrong tag passed to libcurl. Was %s",
+                        CHAR(PRINTNAME(R_ExternalPtrTag(ref)))
+		ERROR;
+	}
+
+	return(handle);
+}
+
 static void
 R_finalizeCurlHandle(SEXP h)
 {
@@ -1243,6 +1269,30 @@ R_finalizeCurlHandle(SEXP h)
      CURLOptionMemoryManager *mgr = RCurl_getMemoryManager(curl);
      curl_easy_cleanup(curl);
      RCurl_releaseManagerMemoryTickets(mgr); 
+   }
+}
+
+static void
+R_finalizeMultiCurlHandle(SEXP h)
+{
+   CURLM *multi_handle = getCURLMPointerRObject(h);
+
+   if(multi_handle) {
+#ifdef RCURL_DEBUG_MEMORY
+     fprintf(stderr, "Clearing %p\n", (void *)multi_handle);fflush(stderr);  
+#endif
+
+     CURLMsg *msg;
+     int numMsgs = 1;
+
+     while (msg = curl_multi_info_read(multi_handle, &numMsgs)) {
+       curl_multi_remove_handle(multi_handle, msg->easy_handle);
+       CURLOptionMemoryManager *mgr = RCurl_getMemoryManager(msg->easy_handle);
+       curl_easy_cleanup(msg->easy_handle);
+       RCurl_releaseManagerMemoryTickets(mgr); 
+     }
+	 
+   curl_multi_cleanup(multi_handle);
    }
 }
 
@@ -1460,7 +1510,7 @@ R_check_bits(int *val, int *bits, int *ans, int *n)
 SEXP
 makeMultiCURLPointerRObject(CURLM *obj)
 {
-    SEXP ans, klass;
+    SEXP ans, klass ref;
 
 	if(!obj) {
 		PROBLEM "NULL CURL handle being returned"
@@ -1470,10 +1520,11 @@ makeMultiCURLPointerRObject(CURLM *obj)
 	
 	PROTECT(klass = MAKE_CLASS("MultiCURLHandle"));
 	PROTECT(ans = NEW(klass));
-	PROTECT(ans = SET_SLOT(ans, Rf_install("ref"), 
-                                R_MakeExternalPtr((void *) obj, Rf_install("MultiCURLHandle"), R_NilValue)));
-
-	/*XXX R_RegisterCFinalizer(ans, R_finalizeMultiCurlHandle); */
+	PROTECT(ref = R_MakeExternalPtr((void *) obj, Rf_install("MultiCURLHandle"), R_NilValue));
+	
+    R_RegisterCFinalizer(ref, R_finalizeMultiCurlHandle);
+	ans = SET_SLOT(ans, Rf_install("ref"), ref);
+	
 	UNPROTECT(3);
 
 	return(ans);


### PR DESCRIPTION
We were having major problems with leaking multi_handles. Our systems keep running out of open file descriptors, and we run this under Rapache so it causes buffer overflows and module crashes and core dumps. I have attempted to fix it. 
